### PR TITLE
Modify 'spark upload' command to upload a default firmware

### DIFF
--- a/lib/commands/spark.js
+++ b/lib/commands/spark.js
@@ -1,8 +1,9 @@
 var fs = require('fs'),
-    rest = require('restler');
+    rest = require('restler'),
+    path = require('path');
 
 module.exports = {
-  usage: "spark upload [access_token] [device_id] [firmware_file]",
+  usage: "spark upload [access_token] [device_id] [default|./path/to/firmware_file.cpp]",
 
   description: "Upload new firmare to your Spark Core",
 
@@ -12,16 +13,16 @@ module.exports = {
     if (["upload"].indexOf(args.shift()) === -1) {
       console.log("No/unrecognized subcommand.");
       console.log("Usage:");
-      console.log("  cylon spark upload [access_token] [device_id] [filename]");
+      console.log("  cylon spark upload [access_token] [device_id] [default|./path/to/firmware_file.cpp]");
       return;
     }
 
     if (args.length < 3) {
       console.log("Invalid number of arguments.");
       console.log("Necessary arguments:");
-      console.log("  - [access_token] # your Spark access token");
-      console.log("  - [device_id]    # your Spark Core's device ID");
-      console.log("  - [filename]     # filename of app you'd like to upload");
+      console.log("  - [access_token]     # your Spark access token");
+      console.log("  - [device_id]        # your Spark Core's device ID");
+      console.log("  - [default|filename] # filename of app you'd like to upload, or 'default' to upload the default firmware");
       return;
     }
 
@@ -30,6 +31,10 @@ module.exports = {
         filename = args.shift(),
         url = "https://api.spark.io/v1/devices/" + device_id,
         length;
+
+    if (filename === "default") {
+      filename = path.join(__dirname, "support/spark/default.cpp");
+    }
 
     fs.exists(filename, function(exists) {
       if (!exists) {

--- a/lib/commands/support/spark/default.cpp
+++ b/lib/commands/support/spark/default.cpp
@@ -1,0 +1,104 @@
+/**
+ * Spark Core - THG Default Firmware
+ *
+ * Copyright (c) 2014 The Hybrid Group
+ * Licensed under the Apache 2.0 license.
+ */
+
+// Includes
+#include "application.h"
+
+// Function prototypes
+int sparkDigitalRead(String pin);
+int sparkDigitalWrite(String command);
+int sparkAnalogRead(String pin);
+int sparkAnalogWrite(String command);
+
+void setup()
+{
+	Spark.function("digitalread", sparkDigitalRead);
+	Spark.function("digitalwrite", sparkDigitalWrite);
+
+	Spark.function("analogread", sparkAnalogRead);
+	Spark.function("analogwrite", sparkAnalogWrite);
+}
+
+int sparkDigitalRead(String pin)
+{
+	int pinNumber = pin.charAt(1) - '0';
+	if (pinNumber < 0 || pinNumber > 7) { return -1; }
+
+	if (pin.startsWith("D")) {
+		pinMode(pinNumber, INPUT_PULLDOWN);
+		return digitalRead(pinNumber);
+	} else if (pin.startsWith("A")) {
+		pinMode(pinNumber + 10, INPUT_PULLDOWN);
+		return digitalRead(pinNumber + 10);
+	}
+
+	return -2;
+}
+
+int sparkDigitalWrite(String command)
+{
+	bool value = 0;
+	int pinNumber = command.charAt(1) - '0';
+
+	if (pinNumber < 0 || pinNumber > 7) { return -1; }
+
+	if (command.substring(3, 7) == "HIGH") {
+		value = 1;
+	} else if (command.substring(3, 6) == "LOW") {
+		value = 0;
+	} else {
+		return -2;
+	}
+
+	if (command.startsWith("D")) {
+		pinMode(pinNumber, OUTPUT);
+		digitalWrite(pinNumber, value);
+		return 1;
+	} else if (command.startsWith("A")) {
+		pinMode(pinNumber + 10, OUTPUT);
+		digitalWrite(pinNumber + 10, value);
+		return 1;
+	}
+
+	return -3;
+}
+
+int sparkAnalogRead(String pin)
+{
+	int pinNumber = pin.charAt(1) - '0';
+	if (pinNumber < 0 || pinNumber > 7) { return -1; }
+
+	if (pin.startsWith("D")) {
+		pinMode(pinNumber, INPUT);
+		return analogRead(pinNumber);
+	} else if (pin.startsWith("A")) {
+		pinMode(pinNumber + 10, INPUT);
+		return analogRead(pinNumber + 10);
+	}
+
+	return -2;
+}
+
+int sparkAnalogWrite(String command)
+{
+	int pinNumber = command.charAt(1) - '0';
+	if (pinNumber < 0 || pinNumber > 7) { return -1; }
+
+	String value = command.substring(3);
+
+	if (command.startsWith("D")) {
+		pinMode(pinNumber, OUTPUT);
+		analogWrite(pinNumber, value.toInt());
+		return 1;
+	} else if (command.startsWith("A")) {
+		pinMode(pinNumber + 10, OUTPUT);
+		analogWrite(pinNumber + 10, value.toInt());
+		return 1;
+	}
+	
+	return -2;
+}

--- a/test/specs/commands/spark.spec.js
+++ b/test/specs/commands/spark.spec.js
@@ -2,6 +2,7 @@
 
 var rest = require('restler'),
     fs = require('fs'),
+    path = require('path'),
     module = source("commands/spark");
 
 describe("cylon spark", function() {
@@ -18,10 +19,12 @@ describe("cylon spark", function() {
 
     beforeEach(function() {
       stub(console, 'log');
+      stub(path, 'join');
     });
 
     afterEach(function() {
       console.log.restore();
+      path.join.restore();
     });
 
     context("with no arguments", function() {
@@ -68,6 +71,20 @@ describe("cylon spark", function() {
             fs.stat.restore();
             rest.file.restore();
             rest.put.restore();
+          });
+
+          context("if the provided filename is 'default'", function() {
+            var args = ['upload', 'access_token', 'device_id', 'default'];
+
+            beforeEach(function() {
+              path.join.returns("default.cpp")
+            });
+
+            it("uploads the default firmware to the Spark", function() {
+              module.action(args);
+              expect(path.join).to.be.calledWithMatch('', 'default.cpp');
+              expect(rest.file).to.be.calledWithMatch('default.cpp');
+            });
           });
 
           it("makes a PUT request to upload the file", function() {


### PR DESCRIPTION
Adds a default firmware (similar to the Tinker app, and supporting the same API calls) that allows digital/analog read/write operations. Can patch in I2C support once it settles down in the Wiring implementation the Spark crew are using.
